### PR TITLE
fix: args in react comparison

### DIFF
--- a/app/templates/ember-for-react-developers.hbs
+++ b/app/templates/ember-for-react-developers.hbs
@@ -75,8 +75,8 @@ General Grievous: General Kenobi!!
 <p>The same pattern would be written this way in Ember:</p>
 
 <pre><code>&lt;!-- presentation/template.hbs -->
-&lt;>Obi Wan Kenobi: {{@message}}&lt;/p>
-&lt;p>General Grievous: {{@response}}&lt;/p>
+&lt;>Obi Wan Kenobi: \{{@message}}&lt;/p>
+&lt;p>General Grievous: \{{@response}}&lt;/p>
 </code></pre>
 
 <pre><code>&lt;!-- invocation/template.hbs -->


### PR DESCRIPTION
<img width="1043" alt="Screen Shot 2021-12-08 at 8 31 20 AM" src="https://user-images.githubusercontent.com/34726/145217243-0b6b9da2-e62e-4cbf-bc62-541c54ec9633.png">

Fixing the above, notice the args aren't there