### PR TITLE
FIX => Hyper link on `ember-for-react-developers` page

### DIFF
--- a/app/templates/ember-for-react-developers.hbs
+++ b/app/templates/ember-for-react-developers.hbs
@@ -12,7 +12,7 @@
   <figcaption>React is only Components</figcaption>
 </figure>
 
-<p>React is *mostly* components. Interactions with external services such as [Redux](https://redux.js.org/), [GraphQL](https://graphql.org/) or [Orbit.js](https://orbitjs.com/) happen through components backed by a *[Context](https://reactjs.org/docs/context.html)* which we'll dive into in a bit.</p>
+<p>React is *mostly* components. Interactions with external services such as <a href="https://redux.js.org/">Redux</a>, <a href="https://graphql.org/">GraphQL</a> or <a href="https://orbitjs.com/">Orbit.js</a> happen through components backed by a <i><a href="https://reactjs.org/docs/context.html">Context</a></i> which we'll dive into in a bit.</p>
 
 
 <figure>


### PR DESCRIPTION
Please review the PR and let me know if any change is required. Thanks.